### PR TITLE
IOPS-270 - DRY_RUN supports booleans

### DIFF
--- a/terminator.go
+++ b/terminator.go
@@ -115,8 +115,9 @@ func main() {
 		flag.Lookup("v").Value.Set("2")
 	}
 
-	if dryRunStr != "" {
-		dryRun = true
+	dryRun, err := strconv.ParseBool(dryRunStr)
+	if err != nil {
+		glog.Fatalf("Error parsing DRY_RUN value: %s", err)
 	}
 
 	if awsRegion == "" {


### PR DESCRIPTION
In our stringer_spec file I want to have something like this

    - name: DRY_RUN
      value: "{{ _node_terminator_dry_run }}"

To enable DRY_RUN you have to set the value of DRY_RUN to something that parses to 'true'