### PR TITLE
Move deployment API to apps/v1beta1 api for v1.6 and 1.7

### DIFF
--- a/terminator-deployment.yaml
+++ b/terminator-deployment.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1beta1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Note: this is not backward-compatible with Kubernetes 1.5.